### PR TITLE
Fix index view not accepting request object

### DIFF
--- a/restapi/views.py
+++ b/restapi/views.py
@@ -7,5 +7,5 @@ from django.http import HttpResponse
 # Create your views here.
 
 
-def index():
+def index(request):
     return HttpResponse("Hello, world. You're at Rest.")


### PR DESCRIPTION
A request object is passed to the Index view. If we don't accept it it'll throw error.